### PR TITLE
some improvements for this workflow

### DIFF
--- a/parser/parser.php
+++ b/parser/parser.php
@@ -18,9 +18,9 @@ $parsed_categories = $html->find('a.list-2-anchor');
 
 // Push to array
 foreach ($parsed_categories as $parsed_category) {
-  // Push all elements except the "All" one to array
-  if ($parsed_category->plaintext != "All") {
-    array_push($categories, $parsed_category->plaintext);
+    // Push all elements except the "All" one to array
+    if ($parsed_category->plaintext != "All") {
+        array_push($categories, $parsed_category->plaintext);
   }
 }
 
@@ -30,37 +30,51 @@ foreach ($parsed_categories as $parsed_category) {
 
 // For each available category
 foreach ($categories as $category) {
-  // Parse available pages for specific cateogory
-  $html = file_get_html('http://dongerlist.com/category/'.$category);
+    // Parse available pages for specific cateogory
+    $html = file_get_html('http://dongerlist.com/category/'.$category);
 
-  // Find available pages
-  $page_current = $html->find('.wp-pagenavi .current', 0);
-  $page_last = $html->find('.wp-pagenavi .last', 0);
-
-  // Check if pagination available
-  if ($page_current && $page_last) {
-    // While theres a new page available
-    while ($page_current <= $page_last) {
-    // Pagination found => multiple pages for that specific category
-    $html = file_get_html('http://dongerlist.com/category/'.$category.'/page/'.$page_current);
-      foreach($html->find('.list-1-item') as $donger) {
-        // Create tiny array per each donger to save meta data like category
-        $item['donger'] = $donger->find('.donger', 0)->plaintext;
-        $item['category'] = strtolower($category);
-        // Push to $dongers[] array
-        array_push($dongers, $item);
+    // Find available pages
+    $page = 1;
+    $page_last = strip_tags($html->find('.wp-pagenavi .last', 0));
+    // Check if pagination available
+    if ($page_last) {
+        // While theres a new page available
+        while ($page <= $page_last) {
+            // Pagination found => multiple pages for that specific category
+            $html = file_get_html('http://dongerlist.com/category/'.$category.'/page/'.$page);
+            foreach($html->find('.list-1-item') as $donger) {
+                // Create tiny array per each donger to save meta data like category
+                $item['donger'] = $donger->find('.donger', 0)->plaintext;
+                $item['category'] = strtolower($category);
+                // Push to $dongers[] array
+                array_push($dongers, $item);
       }
       // Continue with next page
-      $page_current++;
+      $page++;
     }
   } else {
-    // No pagination => only one page of dongers
-    foreach($html->find('.list-1-item') as $donger) {
-        // Create tiny array per each donger to save meta data like category
-        $item['donger'] = $donger->find('.donger', 0)->plaintext;
-        $item['category'] = strtolower($category);
-        // Push to $dongers[] array
-        array_push($dongers, $item);
+      $page_larg = strip_tags($html->find('.wp-pagenavi .larger', 0));
+      while ($page_larg){
+              // Pagination found => multiple pages for that specific category
+              $html = file_get_html('http://dongerlist.com/category/'.$category.'/page/'.$page);
+              foreach($html->find('.list-1-item') as $donger) {
+                  // Create tiny array per each donger to save meta data like category
+                  $item['donger'] = $donger->find('.donger', 0)->plaintext;
+                  $item['category'] = strtolower($category);
+                  // Push to $dongers[] array
+                  array_push($dongers, $item);
+      }
+      // Continue with next page
+      $page_larg = strip_tags($html->find('.wp-pagenavi .larger', 0));
+      $page++;
+        }
+            // No pagination => only one page of dongers
+            foreach($html->find('.list-1-item') as $donger) {
+                // Create tiny array per each donger to save meta data like category
+                $item['donger'] = $donger->find('.donger', 0)->plaintext;
+                $item['category'] = strtolower($category);
+                // Push to $dongers[] array
+                array_push($dongers, $item);
     }
   }
 }

--- a/wrapper.php
+++ b/wrapper.php
@@ -49,7 +49,7 @@ if (isset($argv[1])) {
   // If argument is "category" => show dongers of specific category
   } else {
     foreach ($donger_raw as $donger) {
-      if (strtolower($argv[1]) == $donger->category) {
+      if (strpos($donger->category,strtolower($argv[1])) === 0) {
         $dongers[] = $donger->donger;
       }
     }


### PR DESCRIPTION
1. Replace the {query} strict matching with the loose matching which starts from head;
2. Download all categories including 'happy' and 'dongers' which could not be downloaded before;
3. Download all emotions from most categories which's largest count was 30 before;
4. Forgiving my poor English.  ᕕ( ՞ ᗜ ՞ )ᕗ 
